### PR TITLE
make auth variable accessible for extending classes

### DIFF
--- a/src/providers/google-login-provider.ts
+++ b/src/providers/google-login-provider.ts
@@ -7,7 +7,7 @@ export class GoogleLoginProvider extends BaseLoginProvider {
 
   public static readonly PROVIDER_ID: string = "GOOGLE";
 
-  private auth2: any;
+  protected auth2: any;
 
   constructor(private clientId: string) { super(); }
 


### PR DESCRIPTION
This could let users implement their own google login provider, storing token variables in custom user object class instance.